### PR TITLE
Rename linter job in github actions

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -3,7 +3,7 @@ name: Linter
 on: [push, pull_request]
 
 jobs:
-  run_pytest:
+  run_flake8:
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This PR fixes name of the github actions job, that runs flake8 linter.