### PR TITLE
Remove proxy usage from telegram bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,9 @@ Parser, that periodically checks new events on [standupstore.ru](https://standup
     ```
 3. Add settings.py to `susp/` folder by the following template:
     ```python
-    import telegram
     TOKEN = 'your_telegram_bot_token'
-    REQPROXY = telegram.utils.request.Request(  # proxy settings
-        proxy_url='proxy_url',
-        urllib3_proxy_kwargs={'some': 'kwargs'}
-    )
     CHAT_ID = '@your_telegram_channel_name'
+
     EXCEPTIONS_EMAIL_TO = 'email'  # email to which you will receive error logs
     EXCEPTIONS_EMAIL_FROM = 'email'  # email from which error logs will be sent
     SMPT_SERVER = 'smpt_server_adress'

--- a/susp/notifications.py
+++ b/susp/notifications.py
@@ -13,7 +13,7 @@ def post_to_channel(message):
 
     LOG.info('Connecting to the bot and posting message to the channel')
 
-    mybot = telegram.Bot(token=settings.TOKEN, request=settings.REQPROXY)
+    mybot = telegram.Bot(token=settings.TOKEN)
     mybot.send_message(chat_id=settings.CHAT_ID, text=message, parse_mode='Markdown')
 
     LOG.info('Message posted to the channel')


### PR DESCRIPTION
Proxy not needed anymore since telegram API not being blocked anymore.